### PR TITLE
feat(compatibility): replace default config with electric tiles if present

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
         "game",
         "global",
         "log",
+        "mods",
         "prototypes",
         "script",
         "serpent",

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ Adds an upgrade planner that can be used to upgrade tiles. Redux fork with addit
 
 Hold the upgrade planner in your hand to configure it. Hold shift to clear tile ghosts.
 
+## Mod compatibility
+
+The tile upgrade planner should be compatible with any tile from other mods. If the following mods are detected, the default config is changed accordingly.
+
+- [Electric Tiles](https://mods.factorio.com/mod/electric-tiles): The default config is completely replaced with an upgrade path to replace each vanilla tile with the corresponding electric tile.
+
+If you want to see default config support for other mods, feel free to open a discussion thread on the mod portal or a GitHub issue.
+
 ## Credits
 
 - Thanks to [calcwizard](https://mods.factorio.com/user/calcwizard) for creating the original mod.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 2.1.0
+Date: 2025-09-14
+  Compatibility:
+    - If Electric Tiles are installed, the planner default config is replaced with upgrades from normal to electric tiles.
+---------------------------------------------------------------------------------------------------
 Version: 2.0.0
 Date: 2025-09-14
   Info:

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "tile-upgrade-planner-redux",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "factorio_version": "2.0",
     "title": "Tile Upgrade Planner Redux",
     "author": "calcwizard, MeteorSwarm, QuingKhaos",

--- a/shared.lua
+++ b/shared.lua
@@ -1,3 +1,17 @@
+function check_for_active_mod(name)
+  if not name then return false end
+
+  if mods and mods[name] then
+    return true
+  end
+
+  if script and script.active_mods[name] then
+    return true
+  end
+
+  return false
+end
+
 local blacklist = {
   "landfill"
 }
@@ -14,6 +28,26 @@ for _, v in pairs(blacklist) do
 end
 --]]
 
+local default_mapping = {
+  {source = "stone-path", target = "concrete"},
+  {source = "concrete", target = "refined-concrete"},
+  {source = "hazard-concrete-left", target = "refined-hazard-concrete-left"},
+  {source = "hazard-concrete-right", target = "refined-hazard-concrete-right"},
+}
+
+-- Electric Tiles support
+if check_for_active_mod("electric-tiles") then
+  default_mapping = {
+    {source = "stone-path", target = "F077ET-stone-path"},
+    {source = "concrete", target = "F077ET-concrete"},
+    {source = "refined-concrete", target = "F077ET-refined-concrete"},
+    {source = "hazard-concrete-left", target = "F077ET-hazard-concrete-left"},
+    {source = "hazard-concrete-right", target = "F077ET-hazard-concrete-right"},
+    {source = "refined-hazard-concrete-left", target = "F077ET-refined-hazard-concrete-left"},
+    {source = "refined-hazard-concrete-right", target = "F077ET-refined-hazard-concrete-right"},
+  }
+end
+
 return {
   names = {
     planner = "tile-upgrade-planner",
@@ -23,11 +57,5 @@ return {
   },
 
   tile_filters = tile_filters,
-
-  default_mapping = {
-    {source = "stone-path", target = "concrete"},
-    {source = "concrete", target = "refined-concrete"},
-    {source = "hazard-concrete-left", target = "refined-hazard-concrete-left"},
-    {source = "hazard-concrete-right", target = "refined-hazard-concrete-right"},
-  },
+  default_mapping = default_mapping
 }


### PR DESCRIPTION
Support for [Electric Tiles](https://mods.factorio.com/mod/electric-tiles): the default config is completely replaced with an upgrade path to replace each vanilla tile with the corresponding electric tile.